### PR TITLE
Allow fastqs to be gzipped

### DIFF
--- a/default_protocol/pipelines/demux_map/Snakefile
+++ b/default_protocol/pipelines/demux_map/Snakefile
@@ -79,6 +79,7 @@ rule all:
         expand(config["output_path"]+ "/{filename_stem}.csv", filename_stem=config["filename_stem"])
 
 ##### Modules #####
+include: "rules/unzip.smk"
 include: "rules/demultiplex.smk"
 include: "rules/map.smk"
 

--- a/default_protocol/pipelines/demux_map/rules/map.smk
+++ b/default_protocol/pipelines/demux_map/rules/map.smk
@@ -5,7 +5,7 @@ rule minimap2:
     information in the header.
     """
     input:
-        fastq= config["input_path"] + "/{filename_stem}.fastq",
+        fastq=get_unzipped_fastq,
         ref= config["references_file"]
     output:
         temp(config["output_path"] + "/temp/{filename_stem}.paf")
@@ -23,7 +23,6 @@ rule minimap2:
 #read and writes all reads, even if they don't have a hit (no hit written as ``*`` in paf file)
 
 
-
 rule parse_mapping:
     """
     This rule takes the FASTQ with demuxing done as well as the minimap output (rule: `minimap2`)
@@ -33,7 +32,7 @@ rule parse_mapping:
     """
     input:
         fastq=get_demuxed_fastq,
-        mapped= config["output_path"] + "/temp/{filename_stem}.paf",
+        mapped=config["output_path"] + "/temp/{filename_stem}.paf",
         reference_file = config["references_file"],
     params:
         path_to_script = workflow.current_basedir,

--- a/default_protocol/pipelines/demux_map/rules/unzip.smk
+++ b/default_protocol/pipelines/demux_map/rules/unzip.smk
@@ -1,0 +1,21 @@
+rule unzip:
+    """
+    Uses the python standard library to copy a gzipped file to an unzipped file.
+    Would be faster to use shell commands, but this reduces dependencies
+    """
+    input:
+        config["input_path"] + "/{filename_stem}.fastq.gz"
+    output:
+        temp(config["output_path"] + "/temp/{filename_stem}.fastq")
+    run:
+        import gzip
+        import shutil
+        with gzip.open(input[0], 'rb') as f_in:
+            with open(output[0], 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+
+
+def get_unzipped_fastq(wildcards):
+    if config["filename_ext"] == ".fastq.gz":
+        return config["output_path"] + "/temp/{filename_stem}.fastq" # will call rule `unzip` to make this file
+    return config["input_path"] + "/{filename_stem}.fastq"

--- a/server/watchBasecalledFiles.js
+++ b/server/watchBasecalledFiles.js
@@ -18,26 +18,24 @@ const path = require('path');
 const { sleep, verbose, log, warn } = require('./utils');
 const { makeFileSortFunction } = require("./startUp");
 
-const newFastqFileHandler = (newfile) => {
-  try{
-    const pathInfo = path.parse(newfile);
-    if (pathInfo.ext !== ".fastq") return;
-    if (global.filesSeen.has(pathInfo.name)) {
+const newFastqFileHandler = (fileInfo) => {
+  try {
+    if (!fileInfo.looksLikeFastq) return;
+    if (global.filesSeen.has(fileInfo.name)) {
       // This shouldn't happen as FASTQs present at start-up are filtered 
       // against `filesSeen` before being passed to `newFastqFileHandler`
       // Therefore how can a "new" FASTQ already have been seen / annotated?
-      warn(`Detected "new" FASTQ ${pathInfo.name} which has already been seen!`)
+      warn(`Detected "new" FASTQ ${fileInfo.name} which has already been seen!`)
       return;
     }
-    verbose("fastq watcher", `new basecalled file => adding "${pathInfo.name}" to annotation queue.`);
-
+    verbose("fastq watcher", `new basecalled file => adding "${fileInfo.name}" to annotation queue.`);
     global.pipelineRunners.annotation.addToQueue({
-      input_path: pathInfo.dir,
+      input_path: fileInfo.dir,
       output_path: global.config.run.annotatedPath,
-      filename_stem: pathInfo.name
+      filename_stem: fileInfo.name,
+      filename_ext: fileInfo.ext
     });
-
-    global.filesSeen.add(pathInfo.name);
+    global.filesSeen.add(fileInfo.name);
   } catch (err) {
     console.log(err);
   }
@@ -60,21 +58,25 @@ const startWatcher = () => {
   log(`Scanning folder ${global.config.run.basecalledPath} for FASTQs`);
   log(`(basecalled files which exist here (or are created here by MinKNOW) will be annotated and loaded)\n`);
   watcher.on("add", (filepath) => {
+    const fileInfo = getFileInfo(filepath);
     if (initialScanComplete) {
-      newFastqFileHandler(filepath);
+      newFastqFileHandler(fileInfo);
     } else {
-      if (path.parse(filepath).ext === ".fastq") {
-        fastqsAtInitialScan.push(filepath)
+      if (fileInfo.looksLikeFastq) {
+        fastqsAtInitialScan.push(fileInfo)
       }
     }
   });
   watcher.on('ready', () => {
+    // ready event fires at the end of the initial scan
     const filepathsToBeAnnotated = fastqsAtInitialScan
-        .filter((fp) => !global.filesSeen.has(path.basename(fp, ".fastq")))
-    log(`Initial scan for FASTQs complete. Found ${fastqsAtInitialScan.length} files, ${filepathsToBeAnnotated.length} of which had not already been annotated.`);
-    filepathsToBeAnnotated
-      .sort(makeFileSortFunction(".fastq"))
-      .forEach((filepath) => newFastqFileHandler(filepath))
+      .filter((fileInfo) => !global.filesSeen.has(fileInfo.name))
+    log(`Initial scan for FASTQs complete. Found ${fastqsAtInitialScan.length} files, ${filepathsToBeAnnotated.length} of which are unannotated (unprocesed).`);
+    if (filepathsToBeAnnotated.length) {
+      filepathsToBeAnnotated
+        .sort(makeFileSortFunction((f) => f.name))
+        .forEach((filepath) => newFastqFileHandler(filepath))
+    }
     initialScanComplete = true;
     log(`Watching for new files`);
   });
@@ -97,6 +99,21 @@ const startBasecalledFilesWatcher = async () => {
     await sleep(5000);
     log("INFO: basecalled directory doesn't yet exist. Checking again in 5s.")
   }
+}
+
+function getFileInfo(filePath) {
+  const pathInfo = path.parse(filePath);
+  const ext = pathInfo.ext===".fastq" ? ".fastq" : 
+    (pathInfo.ext===".gz" && pathInfo.name.endsWith(".fastq")) ? ".fastq.gz" :
+    "unknown";
+  return {
+    looksLikeFastq: (ext===".fastq" || ext===".fastq.gz"),
+    root: pathInfo.root,
+    dir: pathInfo.dir,
+    base: pathInfo.base,
+    name: pathInfo.base.replace(ext, ''),
+    ext
+  };
 }
 
 


### PR DESCRIPTION
Closes #64

## Changes

(1) The FASTQ watcher is refactored to be able to detect ".fastq.gz" files

(2) The `demux_map` snakemake pipeline recieves an additional config argument `filename_ext` and will (temporarily) unzip the input as necessary. 


## Testing

I've tested it locally using all the permutations of (guppy-demuxed, undemuxed), (fastq, fastq.gz), (nCoV, EBOV) but this needs testing on other platforms etc as it changes the code by which we detect new FASTQ files. Can be tested by installing RAMPART from this branch. @mattdmem and/or @aineniamh would you be able to test?


