### PR TITLE
Made the number of threads used during mapping and demultiplexing configurable.

### DIFF
--- a/default_protocol/pipelines/demux_map/config.yaml
+++ b/default_protocol/pipelines/demux_map/config.yaml
@@ -21,6 +21,7 @@ barcode_set: "native" # [none,native,rapid,pcr,all], defaults to `native`, `all`
 limit_barcodes_to: #barcode csv string e.g. NB01,NB02,NB03,NB04,NB05,NB06
 barcode_threshold: 80
 barcode_diff: 5
+threads: 2
 
 ##### Filtering options #####
 

--- a/default_protocol/pipelines/demux_map/rules/demultiplex.smk
+++ b/default_protocol/pipelines/demux_map/rules/demultiplex.smk
@@ -13,8 +13,7 @@ rule demultiplex_porechop:
         limit_barcodes_to = limit_barcodes_to,
         threshold = "--barcode_threshold " + str(config["barcode_threshold"]),
         diff = "--barcode_diff " + str(config["barcode_diff"])
-    threads:
-        2
+    threads: config["threads"]
     output:
         temp(config["output_path"] + "/temp/{filename_stem}.fastq")
     shell:
@@ -23,7 +22,7 @@ rule demultiplex_porechop:
         --verbosity 0 \
         -i {input:q} \
         -o {output:q} \
-        --threads 2 \
+        --threads {threads} \
         --barcode_labels \
         {params.threshold} \
         {params.diff}\

--- a/default_protocol/pipelines/demux_map/rules/map.smk
+++ b/default_protocol/pipelines/demux_map/rules/map.smk
@@ -9,9 +9,10 @@ rule minimap2:
         ref= config["references_file"]
     output:
         temp(config["output_path"] + "/temp/{filename_stem}.paf")
+    threads: config["threads"]
     shell:
         """
-        minimap2 -x map-ont \
+        minimap2 -t {threads} -x map-ont \
         --secondary=no \
         --paf-no-hit \
         --cs \


### PR DESCRIPTION
It should not affect anything but allows for a custom number of threads when the Snakemake pipelines are invoked manually.