### PR TITLE
improve display when no fastq data is available for a sample

### DIFF
--- a/src/components/SamplePanel/infoRow.js
+++ b/src/components/SamplePanel/infoRow.js
@@ -40,13 +40,19 @@ const TriggerPanelExpand = ({sampleColour, isExpanded, handleClick}) => {
 const InfoRow = ({sampleName, sampleData, sampleColour, menuItems, handleClick, isExpanded, timeSinceLastDataUpdate}) => {
     const summaryTitle = `${sampleName}`;
 
-    let summaryText = `${sampleData.mappedCount} reads mapped | ${sampleData.processedCount} processed | ` +
-        `${sampleData.temporal.length > 0 ? Math.round(sampleData.temporal[sampleData.temporal.length - 1].processedRate) : "N/A"} reads/sec `;
-    const readLastSeen = sampleData.readsLastSeen+timeSinceLastDataUpdate;
-    if (readLastSeen > 5) {
-      const timeFormatter = makeTimeFormatter();
-      summaryText += `| read last seen ${timeFormatter(readLastSeen)} ago`
+    let summaryText;
+    if (sampleData.processedCount === 0) {
+      summaryText = "No data yet written to FASTQ"
+    } else {
+      summaryText = `${sampleData.mappedCount} reads mapped | ${sampleData.processedCount} processed | `;
+      summaryText += `${sampleData.temporal.length > 0 ? Math.round(sampleData.temporal[sampleData.temporal.length - 1].processedRate) : "N/A"} reads/sec `;
+      const readLastSeen = sampleData.readsLastSeen+timeSinceLastDataUpdate;
+      if (readLastSeen > 5) {
+        const timeFormatter = makeTimeFormatter();
+        summaryText += `| read last seen ${timeFormatter(readLastSeen)} ago`
+      }
     }
+
     return (
         <div className="infoRow" style={{color: sampleColour}}>
             <div>

--- a/src/components/Sidebar/Report.js
+++ b/src/components/Sidebar/Report.js
@@ -157,6 +157,15 @@ const ReadCounts = ({data, config}) => {
       </thead>
       <tbody>
         {names.map((name) => {
+          /* don't display stats if no reads have been processed */
+          if (data[name].processedCount === 0) {
+            return (
+              <tr>
+                <th>{name}</th>
+                <td colspan="5" style={{textAlign: "center", fontStyle: "italic"}}>No data yet written to FASTQ</td>
+              </tr>
+            )
+          }
           const readLengths = getReadLengths(data[name].readLengths);
           return (
             <tr key={name}>


### PR DESCRIPTION
In situations where a barcode is being displayed because it's defined in the run-config or via the `--barcodes` but there are no reads available there are two possible situations:
1. There are truly no reads
2. There are reads but fewer than the threshold for MinKNOW / guppy to write out a FASTQ (normally 4000). Sometimes this is being written but kept open, but sometimes it's cached so no file yet exists.

Unfortunately we can't distinguish between the two so this PR improves our language in the sample panels and the report:

![image](https://user-images.githubusercontent.com/8350992/79719093-d5185800-8331-11ea-8160-0c9ad5d15529.png)

![image](https://user-images.githubusercontent.com/8350992/79719104-dba6cf80-8331-11ea-949b-c8f71d8de37e.png)
