### PR TITLE
Call snakemake with --cores argument

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "artic-rampart",
-  "version": "1.1.0-prerelease",
+  "version": "1.2.0rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "d3-shape": "^1.2.0",
     "eslint-plugin-import": "^2.17.2",
     "express": "^4.16.3",
+    "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "rc-slider": "^8.7.1",

--- a/server/PipelineRunner.js
+++ b/server/PipelineRunner.js
@@ -46,6 +46,8 @@ class PipelineRunner {
 
         this._processedCount = 0;
 
+        this._threadsRequested = config.threads_requested || 1;
+
         this._isRunning = false;
         if (queue) {
             this._onSuccess = onSuccess; // callback
@@ -160,6 +162,9 @@ class PipelineRunner {
             }
             spawnArgs.push('--nolock');
             spawnArgs.push('--rerun-incomplete');
+
+            /* Snakemake accepts a --cores arg, and 5.11 made this compulsory */
+            spawnArgs.push(...['--cores', this._threadsRequested]);
 
             verbose(`pipeline (${this._name})`, `snakemake ` + spawnArgs.join(" "));
 


### PR DESCRIPTION
Snakemake accepts a `--cores` arg, and snakemake 5.11 made this compulsory so that our current snakemake calls will all fail if a user has v5.11 or higher.

Separately, PR #78 shows an example of setting the number of threads for snakemake in the config file.

We now add `--cores` to each snakemake call, and set it to 1 _or_ the number of threads requested _if_ they are specified in the pipeline's snakemake config YAML or via the command line args for the snakemake call.